### PR TITLE
atomic: 32bit ARM ends at v7 - v8 is 64bit

### DIFF
--- a/cppmyth/src/atomic.h
+++ b/cppmyth/src/atomic.h
@@ -144,7 +144,7 @@ static CC_INLINE unsigned atomic_increment(atomic_t *valp)
   /* The value for __val is in '__oldval' */
   __val = __oldval;
 
-#elif (defined __ARM_ARCH && __ARM_ARCH >= 7)
+#elif (defined __ARM_ARCH && __ARM_ARCH == 7)
   int inc = 1;
   __asm__ volatile (
     "dmb     ish\n"           /* Memory barrier */
@@ -280,7 +280,7 @@ static CC_INLINE unsigned atomic_decrement(atomic_t *valp)
   /* The value for __val is in '__oldval' */
   __val = __oldval;
 
-#elif (defined __ARM_ARCH && __ARM_ARCH >= 7)
+#elif (defined __ARM_ARCH && __ARM_ARCH == 7)
   int dec = 1;
   __asm__ volatile (
     "1:"


### PR DESCRIPTION
AArch64 (armv8) sets __ARM_ARCH to 8 but has other assembler