### PR TITLE
Fix double close when failing to connect to mythbackend.

### DIFF
--- a/cppmyth/src/private/socket.cpp
+++ b/cppmyth/src/private/socket.cpp
@@ -170,6 +170,7 @@ static int __connectAddr(struct addrinfo *addr, net_socket_t *s, int rcvbuf)
     err = LASTERROR;
     DBG(DBG_ERROR, "%s: failed to connect (%d)\n", __FUNCTION__, err);
     closesocket(*s);
+    *s = INVALID_SOCKET_VALUE;
 #ifndef __WINDOWS__
     signal(SIGALRM, old_sighandler);
     alarm(old_alarm);


### PR DESCRIPTION
A user reported a crash in Kodi when it fails to connect to his MythTV backend:
https://forum.kodi.tv/showthread.php?tid=349392

strace points to kodi-pvr-mythtv double closing a file.
The first close happens at lib/cppmyth/src/private/socket.cpp:172
It closes again on cleanup at lib/cppmyth/src/private/socket.cpp:432
lib/cppmyth/src/private/socket.cpp:172 didn't mark the socket invalid after closing.